### PR TITLE
remove quote = false in write out step

### DIFF
--- a/data_prep_scripts/auto_merge_duplicates_wrapper.R
+++ b/data_prep_scripts/auto_merge_duplicates_wrapper.R
@@ -27,4 +27,4 @@ md$merged_record = '0'
 source("data_prep_scripts/merge_duplicates_functions.R")
 md <- merge_all_duplicates_in_dataframe(md, sfp)
 
-write.csv(md, stdout(), quote = FALSE, row.names = FALSE)
+write.csv(md, stdout(), row.names = FALSE)


### PR DESCRIPTION
to fix issue with merge_datasets.csv not being properly aligned, it appears to be linked to an argument in write.csv in last step of workflow (which I added before to clean up the quotes, sorry!). trying now without.