### PR TITLE
Modify test yaml to prevent secrets fail

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - '**'        # matches every branch
-  pull_request:
+  pull_request_target:
     branches:
       - '**'        # matches every branch
 jobs:

--- a/.github/workflows/rtest.yaml
+++ b/.github/workflows/rtest.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - '**'        # i.e. "Every branch"
-  pull_request:
+  pull_request_target:
     branches:
       - '**'        # i.e. "Every branch"
   workflow_dispatch:
@@ -22,6 +22,6 @@ jobs:
     - name: Get current directory
       run: pwd
     - name: Run testthat
-      env: 
+      env:
         mapbox_key: ${{ secrets.MAPBOX_API_KEY }}
       run: Rscript run_tests.R $mapbox_key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# How to Contribute
+
+Thanks for pitching in with the Pittsburgh Food Access Map project.  We've created these guidelines to make contributing to this effort as easy as possible.  If there is some aspect of the process that is unclear, please let us know.
+
+## We Develop with git and Github
+We use git as our source control technology, and github to host code, track issues and feature requests, issue build actions, and to accept pull requests.
+
+## Commit Guidelines
+Always write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
+
+    $ git commit -m "A brief summary of the commit
+    >
+    > A paragraph describing what changed and its impact."
+
+## Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Issue that pull request!
+
+## Any contributions you make will be under the MIT Software License
+In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
+
+## Report bugs using Github's [issues](https://github.com/briandk/transcriptase-atom/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](); it's that easy!
+
+## Write bug reports with detail, background, and sample code
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Give sample code if you can. [This stackoverflow question](http://stackoverflow.com/q/12488905/180626) includes sample code that *anyone* with a base R setup can run to reproduce what I was seeing
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+People *love* thorough bug reports. I'm not even kidding.
+
+## Use a Consistent Coding Style
+TBD
+
+## License
+By contributing, you agree that your contributions will be licensed under its MIT License.
+
+## References
+This document was adapted from the contribution guidelines developed by [Briadk](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62)


### PR DESCRIPTION
This PR includes modifications to two of the YAML configurations for tests that are run after every push or pull request.

The modifications were made in response to issues with secrets not being found when tests were run against the forked version of a repository.  The fix for this issue is described in [the following thread](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425)